### PR TITLE
Fix Prettier config warnings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 120,
-  "svelteSortOrder": "scripts-styles-markup",
+  "svelteSortOrder": "options-scripts-styles-markup",
   "svelteStrictMode": false,
   "bracketSameLine": true,
   "svelteAllowShorthand": true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
   "printWidth": 120,
   "svelteSortOrder": "scripts-styles-markup",
   "svelteStrictMode": false,
-  "svelteBracketNewLine": false,
+  "bracketSameLine": true,
   "svelteAllowShorthand": true,
   "svelteIndentScriptAndStyle": true
 }


### PR DESCRIPTION
- Convert deprecated svelteBracketNewLine (false) to bracketSameLine (true)
- Add required "options" value to svelteSortOrder

Before:
<img width="1716" alt="CleanShot 2022-08-05 at 14 13 52@2x" src="https://user-images.githubusercontent.com/353790/183136917-e7afc40e-da04-4cb0-81fc-35931a3b9386.png">

After:
<img width="790" alt="CleanShot 2022-08-05 at 14 13 23@2x" src="https://user-images.githubusercontent.com/353790/183136957-f933fb4c-2715-493b-8243-7e050d24621b.png">
